### PR TITLE
Remove unnecessary commons-io exclusion from exampledata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,12 +90,6 @@
             <groupId>com.vaadin</groupId>
             <artifactId>exampledata</artifactId>
             <version>6.2.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-io</groupId>
-                    <artifactId>commons-io</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- Remove `commons-io` exclusion from `exampledata` dependency in `pom.xml`
- The exclusion causes `NoClassDefFoundError: org/apache/commons/io/IOUtils` at startup because `exampledata` (via `FileCache`) requires `commons-io` at runtime
- With Spring Boot 4.x, `commons-io` no longer arrives transitively

Fixes #394